### PR TITLE
add ropensci-review-tools pkgs to not_transferred list

### DIFF
--- a/inst/automation/not_transferred.txt
+++ b/inst/automation/not_transferred.txt
@@ -6,3 +6,8 @@ https://github.com/r-lib/credentials.git
 https://github.com/ropensci-org/rodev
 https://github.com/ropensci-org/roblog
 https://github.com/ropensci-org/pkgreviewr
+https://github.com/ropensci-review-tools/autotest
+https://github.com/ropensci-review-tools/pkgstats
+https://github.com/ropensci-review-tools/pkgcheck
+https://github.com/ropensci-review-tools/srr
+https://github.com/ropensci-review-tools/roreviewapi


### PR DESCRIPTION
Ahoy @maelle and @sckott:

@jeroen suggested this was the way to get the doc server building docs for these repos. Anything else need doing?